### PR TITLE
Fix admin auth by adding temporary password fallback

### DIFF
--- a/server.js
+++ b/server.js
@@ -1011,7 +1011,7 @@ app.get("/api/admin/password-status", (req, res) => {
 app.get("/api/admin/logs", (req, res) => {
   try {
     const { password } = req.query;
-    const adminPassword = process.env.ADMIN_PASSWORD || 'bruhdang';
+    const adminPassword = temporaryAdminPassword || process.env.ADMIN_PASSWORD || 'bruhdang';
     if (password !== adminPassword) {
       return res.status(401).json({ error: 'Unauthorized' });
     }
@@ -1138,7 +1138,7 @@ app.get("/health", (req, res) => {
 // Supabase tables endpoints for admin panel
 app.get("/api/admin/tables/:tableName", async (req, res) => {
   const { password } = req.query;
-  const adminPassword = process.env.ADMIN_PASSWORD || 'bruhdang';
+  const adminPassword = temporaryAdminPassword || process.env.ADMIN_PASSWORD || 'bruhdang';
   if (password !== adminPassword) {
     return res.status(401).json({ error: 'Unauthorized' });
   }
@@ -1213,7 +1213,7 @@ app.get("/api/admin/tables/:tableName", async (req, res) => {
 // Current users endpoint - get active sessions
 app.get("/api/admin/current-users", async (req, res) => {
   const { password } = req.query;
-  const adminPassword = process.env.ADMIN_PASSWORD || 'bruhdang';
+  const adminPassword = temporaryAdminPassword || process.env.ADMIN_PASSWORD || 'bruhdang';
   if (password !== adminPassword) {
     return res.status(401).json({ error: 'Unauthorized' });
   }


### PR DESCRIPTION
## Purpose
Based on the conversation history, users were experiencing authentication issues when using temporary passwords for admin access. The system was showing "database loading error because of auth" when logged in with temporary credentials, indicating the authentication flow wasn't properly handling temporary admin passwords.

## Code changes
- Updated admin authentication logic in three endpoints (`/api/admin/logs`, `/api/admin/tables/:tableName`, `/api/admin/current-users`)
- Added `temporaryAdminPassword` as the primary fallback before checking `process.env.ADMIN_PASSWORD`
- Modified the password validation chain to: `temporaryAdminPassword || process.env.ADMIN_PASSWORD || 'bruhdang'`
- This ensures temporary admin passwords are properly recognized and validated during authentication

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 16`

🔗 [Edit in Builder.io](https://builder.io/app/projects/32e132450cf448c79043720b5929a233/glow-studio)

👀 [Preview Link](https://32e132450cf448c79043720b5929a233-glow-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>32e132450cf448c79043720b5929a233</projectId>-->
<!--<branchName>glow-studio</branchName>-->