### PR TITLE
feat: Add maintenance page

### DIFF
--- a/public/maintenance.html
+++ b/public/maintenance.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>ATC24 - Under Maintenance</title>
+  <link href="https://fonts.googleapis.com/css2?family=Funnel+Display:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    body {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      text-align: center;
+    }
+    .maintenance-container {
+      max-width: 600px;
+    }
+    .maintenance-container h1 {
+        font-size: 32px;
+    }
+    .maintenance-container p {
+        font-size: 18px;
+        margin-top: 15px;
+    }
+  </style>
+</head>
+<body>
+<div class="container maintenance-container">
+  <div class="header">
+    <h1>24IFR is currently under maintenance.</h1>
+    <p style="color: var(--text-muted);">
+      The application is not usable at this time. We'll be back shortly.
+    </p>
+  </div>
+</div>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -947,6 +947,11 @@ app.get("/license", trackVisit, (req, res) => {
   res.sendFile(path.join(__dirname, "public", "license.html"));
 });
 
+// Serve the maintenance page
+app.get("/maintenance", (req, res) => {
+  res.sendFile(path.join(__dirname, "public", "maintenance.html"));
+});
+
 // Serve admin panel (don't track admin visits to avoid skewing analytics)
 app.get("/admin", (req, res) => {
   res.sendFile(path.join(__dirname, "public", "admin.html"));


### PR DESCRIPTION
This commit introduces a new maintenance page for the application.

- Creates a new `public/maintenance.html` file with a user-friendly message indicating that the site is under maintenance.
- The page is styled to match the existing theme of the website.
- Adds a new route `/maintenance` in `server.js` to serve the new page.