### PR TITLE
feat: Add logo, fix UI/auth, and restyle buttons

### DIFF
--- a/database.migration.fix.sql
+++ b/database.migration.fix.sql
@@ -171,6 +171,28 @@ CREATE TABLE IF NOT EXISTS admin_settings (
     CONSTRAINT single_row_constraint CHECK (id = 1)
 );
 
+-- =============================================================================
+-- FUNCTION: is_admin (NEW)
+-- Checks if the currently authenticated user has admin privileges.
+-- =============================================================================
+CREATE OR REPLACE FUNCTION is_admin()
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  IF auth.role() = 'authenticated' THEN
+    RETURN (
+      SELECT is_admin
+      FROM public.discord_users
+      WHERE id = auth.uid()
+    );
+  ELSE
+    RETURN FALSE;
+  END IF;
+END;
+$$;
+
 -- Enable RLS for admin_settings
 ALTER TABLE admin_settings ENABLE ROW LEVEL SECURITY;
 
@@ -220,26 +242,6 @@ BEGIN
 END $$;
 
 -- =============================================================================
--- FUNCTION: is_admin (NEW)
--- Checks if the currently authenticated user has admin privileges.
--- =============================================================================
-CREATE OR REPLACE FUNCTION is_admin()
-RETURNS BOOLEAN
-LANGUAGE plpgsql
-SECURITY DEFINER
-AS $$
-BEGIN
-  IF auth.role() = 'authenticated' THEN
-    RETURN (
-      SELECT is_admin
-      FROM public.discord_users
-      WHERE id = auth.uid()
-    );
-  ELSE
-    RETURN FALSE;
-  END IF;
-END;
-$$;
 
 -- =============================================================================
 -- FUNCTION: upsert_user_session


### PR DESCRIPTION
This commit introduces the company logo to all pages, increases its size, unifies button styles, and addresses several issues in the admin panel and main page:

- **Logo:** The website logo is added to the header of all pages. Its size has been increased to 150px wide and the spacing adjusted based on user feedback.
- **Button Styles:** The "Login with Discord" buttons are restyled. The main page button now has white text and a glowing yellow animated border.
- **Smooth Transitions:** Fade-in/out animations are added for authentication state changes on the main page and admin panel.
- **Discord Auth:** The Discord authentication flow is updated to no longer request the 'email' scope.
- **Admin Panel Layout:** The CSS for the settings grid is adjusted to be more responsive.
- **Table UI:** A new info pop-up is implemented for tables in the admin panel to show full content of truncated cells.
- **Add Admin User:** A bug in the 'Add Admin User' functionality is fixed by passing roles as a proper array to the database function.
- **Advanced Configuration:** The "Advanced Configuration" section on the main page is made collapsible and closed by default, moved to a more prominent location, and its layout is adjusted to prevent overflow.
- **Health Endpoint:** A duplicate, less-detailed `/health` endpoint is removed from `server.js` to fix issues with the system health display in the admin panel.
- **Generate Clearance Bug:** A bug that prevented clearance generation due to an incorrect element ID has been fixed.
- **SQL Migration:** The `database.migration.fix.sql` script is corrected to define the `is_admin()` function before it is used in RLS policies, and to drop a conflicting duplicate function.