### PR TITLE
feat: Refactor phraseology settings and update controller list

### DIFF
--- a/database.migration.fix.sql
+++ b/database.migration.fix.sql
@@ -214,7 +214,6 @@ DECLARE
       "includeAtis": true,
       "includeSquawk": true,
       "includeFlightLevel": true,
-      "phraseologyStyle": "ICAO",
       "customTemplate": "{CALLSIGN}, {ATC_STATION}, good day. Startup approved. Information {ATIS} is correct. Cleared to {DESTINATION} via {ROUTE}, runway {RUNWAY}. Initial climb {INITIAL_ALT}FT, expect further climb to Flight Level {FLIGHT_LEVEL}. Squawk {SQUAWK}.",
       "includeStartupApproval": true,
       "includeInitialClimb": true

--- a/public/admin.html
+++ b/public/admin.html
@@ -1146,16 +1146,7 @@
             <h3>Clearance Format & Phraseology</h3>
 
             <div class="setting-item">
-              <label class="config-label">Phraseology Standard</label>
-              <select id="phraseologyStyle" onchange="updatePhraseologyTemplate()">
-                <option value="ICAO">ICAO Standard</option>
-                <option value="FAA">FAA Standard</option>
-                <option value="Local">Local Adaptation</option>
-              </select>
-            </div>
-
-            <div class="setting-item">
-              <label class="config-label">Custom Phraseology Format</label>
+              <label class="config-label">Global Phraseology Format</label>
               <textarea id="phraseologyTemplate" placeholder="Enter custom clearance format template...">{CALLSIGN}, {ATC_STATION}, good day. Startup approved. Information {ATIS} is correct. Cleared to {DESTINATION} via {ROUTE}, runway {RUNWAY}. Initial climb {INITIAL_ALT}FT, expect further climb to Flight Level {FLIGHT_LEVEL}. Squawk {SQUAWK}.</textarea>
               <div style="font-size: 12px; color: var(--text-muted); margin-top: 8px;">
                 Available variables: {CALLSIGN}, {ATC_STATION}, {ATIS}, {DESTINATION}, {ROUTE}, {RUNWAY}, {INITIAL_ALT}, {FLIGHT_LEVEL}, {SQUAWK}
@@ -1820,7 +1811,6 @@
         settings = await response.json();
 
         // Clearance format settings
-        document.getElementById('phraseologyStyle').value = settings.clearanceFormat?.phraseologyStyle || 'ICAO';
         document.getElementById('phraseologyTemplate').value = settings.clearanceFormat?.customTemplate || '{CALLSIGN}, {ATC_STATION}, good day. Startup approved. Information {ATIS} is correct. Cleared to {DESTINATION} via {ROUTE}, runway {RUNWAY}. Initial climb {INITIAL_ALT}FT, expect further climb to Flight Level {FLIGHT_LEVEL}. Squawk {SQUAWK}.';
         document.getElementById('includeAtis').checked = settings.clearanceFormat?.includeAtis !== false;
         document.getElementById('includeSquawk').checked = settings.clearanceFormat?.includeSquawk !== false;
@@ -1915,33 +1905,11 @@
       }
     }
 
-    // Phraseology template management
-    function updatePhraseologyTemplate() {
-      const style = document.getElementById('phraseologyStyle').value;
-      const templateField = document.getElementById('phraseologyTemplate');
-
-      let template = '';
-      switch(style) {
-        case 'ICAO':
-          template = '{CALLSIGN}, {ATC_STATION}, good day. Startup approved. Information {ATIS} is correct. Cleared to {DESTINATION} via {ROUTE}, runway {RUNWAY}. Initial climb {INITIAL_ALT}FT, expect further climb to Flight Level {FLIGHT_LEVEL}. Squawk {SQUAWK}.';
-          break;
-        case 'FAA':
-          template = '{CALLSIGN}, {ATC_STATION}. Cleared to {DESTINATION} airport via {ROUTE}, runway {RUNWAY}. Climb and maintain {INITIAL_ALT}, expect {FLIGHT_LEVEL} 10 minutes after departure. Departure frequency will be as published. Squawk {SQUAWK}.';
-          break;
-        case 'Local':
-          template = '{CALLSIGN}, {ATC_STATION}. You are cleared to {DESTINATION} via {ROUTE}, departing runway {RUNWAY}. Climb initially to {INITIAL_ALT} feet, expect flight level {FLIGHT_LEVEL}. Squawk {SQUAWK}. Contact ground for pushback.';
-          break;
-      }
-
-      templateField.value = template;
-    }
-
     // Settings management
     async function saveSettings() {
       try {
         const newSettings = {
           clearanceFormat: {
-            phraseologyStyle: document.getElementById('phraseologyStyle').value,
             customTemplate: document.getElementById('phraseologyTemplate').value,
             includeAtis: document.getElementById('includeAtis').checked,
             includeSquawk: document.getElementById('includeSquawk').checked,

--- a/public/index.html
+++ b/public/index.html
@@ -214,14 +214,6 @@
         <div class="config-section">
           <h3 class="config-section-title">Clearance Format & Phraseology</h3>
           <div class="config-group">
-            <label class="config-label">Phraseology Standard</label>
-            <select id="userPhraseologyStyle" onchange="updateUserPhraseologyTemplate()">
-              <option value="ICAO">ICAO Standard</option>
-              <option value="FAA">FAA Standard</option>
-              <option value="Local">Local Adaptation</option>
-            </select>
-          </div>
-          <div class="config-group">
             <label class="config-label">Custom Phraseology Format</label>
             <textarea id="userPhraseologyTemplate" placeholder="Enter custom clearance format template...">{CALLSIGN}, {ATC_STATION}, good day. Startup approved. Information {ATIS} is correct. Cleared to {DESTINATION} via {ROUTE}, runway {RUNWAY}. Initial climb {INITIAL_ALT}FT, expect further climb to Flight Level {FLIGHT_LEVEL}. Squawk {SQUAWK}.</textarea>
             <div class="template-help">
@@ -300,7 +292,7 @@
       includeAtis: true,
       includeSquawk: true,
       includeFlightLevel: true,
-      phraseologyStyle: "ICAO",
+      customTemplate: "{CALLSIGN}, {ATC_STATION}, good day. Startup approved. Information {ATIS} is correct. Cleared to {DESTINATION} via {ROUTE}, runway {RUNWAY}. Initial climb {INITIAL_ALT}FT, expect further climb to Flight Level {FLIGHT_LEVEL}. Squawk {SQUAWK}.",
       includeStartupApproval: true,
       includeInitialClimb: true
     },
@@ -313,7 +305,6 @@
   // User settings (overrides admin settings)
   let userSettings = {
     clearanceFormat: {
-      phraseologyStyle: "ICAO",
       customTemplate: "",
       includeAtis: true,
       includeSquawk: true,
@@ -367,7 +358,6 @@
   async function saveUserSettings() {
     try {
       // Get values from UI
-      userSettings.clearanceFormat.phraseologyStyle = document.getElementById('userPhraseologyStyle').value;
       userSettings.clearanceFormat.customTemplate = document.getElementById('userPhraseologyTemplate').value;
       userSettings.clearanceFormat.includeAtis = document.getElementById('userIncludeAtis').checked;
       userSettings.clearanceFormat.includeSquawk = document.getElementById('userIncludeSquawk').checked;
@@ -422,10 +412,8 @@
 
   // Update UI elements with user settings
   function updateUserSettingsUI() {
-    document.getElementById('userPhraseologyStyle').value = userSettings.clearanceFormat.phraseologyStyle;
-
     // Set custom template or default template if empty
-    const templateValue = userSettings.clearanceFormat.customTemplate || getDefaultTemplate(userSettings.clearanceFormat.phraseologyStyle);
+    const templateValue = userSettings.clearanceFormat.customTemplate || (adminSettings.clearanceFormat && adminSettings.clearanceFormat.customTemplate) || '';
     document.getElementById('userPhraseologyTemplate').value = templateValue;
 
     document.getElementById('userIncludeAtis').checked = userSettings.clearanceFormat.includeAtis;
@@ -443,27 +431,6 @@
     document.getElementById('userEnableSIDValidation').checked = userSettings.aviation.enableSIDValidation;
   }
 
-  // Get default template based on phraseology style
-  function getDefaultTemplate(style) {
-    switch(style) {
-      case 'ICAO':
-        return '{CALLSIGN}, {ATC_STATION}, good day. Startup approved. Information {ATIS} is correct. Cleared to {DESTINATION} via {ROUTE}, runway {RUNWAY}. Initial climb {INITIAL_ALT}FT, expect further climb to Flight Level {FLIGHT_LEVEL}. Squawk {SQUAWK}.';
-      case 'FAA':
-        return '{CALLSIGN}, {ATC_STATION}. Cleared to {DESTINATION} airport via {ROUTE}, runway {RUNWAY}. Climb and maintain {INITIAL_ALT}, expect {FLIGHT_LEVEL} 10 minutes after departure. Departure frequency will be as published. Squawk {SQUAWK}.';
-      case 'Local':
-        return '{CALLSIGN}, {ATC_STATION}. You are cleared to {DESTINATION} via {ROUTE}, departing runway {RUNWAY}. Climb initially to {INITIAL_ALT} feet, expect flight level {FLIGHT_LEVEL}. Squawk {SQUAWK}. Contact ground for pushback.';
-      default:
-        return '{CALLSIGN}, {ATC_STATION}, good day. Startup approved. Information {ATIS} is correct. Cleared to {DESTINATION} via {ROUTE}, runway {RUNWAY}. Initial climb {INITIAL_ALT}FT, expect further climb to Flight Level {FLIGHT_LEVEL}. Squawk {SQUAWK}.';
-    }
-  }
-
-  // Update user phraseology template when style changes
-  function updateUserPhraseologyTemplate() {
-    const style = document.getElementById('userPhraseologyStyle').value;
-    const templateField = document.getElementById('userPhraseologyTemplate');
-    templateField.value = getDefaultTemplate(style);
-  }
-
   // Get effective settings (user settings override admin settings)
   function getEffectiveSettings() {
     const effective = JSON.parse(JSON.stringify(adminSettings)); // Deep clone
@@ -471,9 +438,6 @@
     // Override with user settings
     if (userSettings.clearanceFormat.customTemplate) {
       effective.clearanceFormat.customTemplate = userSettings.clearanceFormat.customTemplate;
-    }
-    if (userSettings.clearanceFormat.phraseologyStyle) {
-      effective.clearanceFormat.phraseologyStyle = userSettings.clearanceFormat.phraseologyStyle;
     }
     effective.clearanceFormat.includeAtis = userSettings.clearanceFormat.includeAtis;
     effective.clearanceFormat.includeSquawk = userSettings.clearanceFormat.includeSquawk;
@@ -652,12 +616,12 @@
         routePhrase = planRoute || 'as filed';
     }
 
-    // Generate clearance based on user's custom template if available, otherwise use legacy format
+    // Generate clearance based on the effective custom template
     let clearance = '';
+    const template = effectiveSettings.clearanceFormat.customTemplate;
 
-    if (effectiveSettings.clearanceFormat.customTemplate && userSettings.clearanceFormat.customTemplate) {
-      // Use user's custom template
-      clearance = userSettings.clearanceFormat.customTemplate
+    if (template) {
+      clearance = template
         .replace('{CALLSIGN}', callsign)
         .replace('{ATC_STATION}', groundCallsign)
         .replace('{ATIS}', atisInfo)
@@ -667,50 +631,6 @@
         .replace('{INITIAL_ALT}', ifl)
         .replace('{FLIGHT_LEVEL}', flightLevel.replace('FL', '').padStart(3, '0'))
         .replace('{SQUAWK}', squawk);
-    } else {
-      // Fallback to structured clearance generation using effective settings
-      let clearanceParts = [];
-
-      // Basic greeting and callsign
-      if (effectiveSettings.clearanceFormat.phraseologyStyle === "ICAO") {
-        clearanceParts.push(`${callsign}, ${groundCallsign}, good day.`);
-      } else if (effectiveSettings.clearanceFormat.phraseologyStyle === "FAA") {
-        clearanceParts.push(`${callsign}, ${groundCallsign}.`);
-      } else {
-        clearanceParts.push(`${callsign}, ${groundCallsign}, good day.`);
-      }
-
-      // Startup approval
-      if (effectiveSettings.clearanceFormat.includeStartupApproval) {
-        clearanceParts.push("Startup approved.");
-      }
-
-      // ATIS information
-      if (effectiveSettings.clearanceFormat.includeAtis) {
-        clearanceParts.push(`Information ${atisInfo} is correct.`);
-      }
-
-      // Clearance itself
-      clearanceParts.push(`Cleared to ${destination} via ${routePhrase}, runway ${departureRW}.`);
-
-      // Initial climb
-      if (effectiveSettings.clearanceFormat.includeInitialClimb) {
-        clearanceParts.push(`Initial climb ${ifl}FT`);
-
-        // Expected flight level
-        if (effectiveSettings.clearanceFormat.includeFlightLevel && flightLevel !== 'N/A') {
-          clearanceParts[clearanceParts.length - 1] += `, expect further climb to Flight Level ${flightLevel.replace('FL', '').padStart(3, '0')}.`;
-        } else {
-          clearanceParts[clearanceParts.length - 1] += ".";
-        }
-      }
-
-      // Squawk code
-      if (effectiveSettings.clearanceFormat.includeSquawk) {
-        clearanceParts.push(`Squawk ${squawk}.`);
-      }
-
-      clearance = clearanceParts.join(' ');
     }
     document.getElementById("clearanceOutput").textContent = clearance;
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -134,8 +134,8 @@ body {
 .flight-plans {
   max-height: 500px;
   overflow-y: auto;
-  overflow-x: hidden;
-  padding-right: 10px;
+  overflow-x: visible; /* Allow hover effect to extend outside */
+  padding: 5px; /* Add some padding to not cut off shadows */
 }
 
 .flight-plan {
@@ -147,7 +147,7 @@ body {
   cursor: pointer;
   transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
   position: relative;
-  overflow: hidden;
+  /* overflow: hidden; */ /* Removed to prevent hover transform from being cut off */
 }
 
 .flight-plan::before {
@@ -159,6 +159,7 @@ body {
   height: 100%;
   background: linear-gradient(90deg, transparent, rgba(245, 222, 64, 0.1), transparent);
   transition: left 0.5s ease;
+  z-index: 1; /* Ensure it's above the background but below content */
 }
 
 .flight-plan:hover::before {
@@ -170,6 +171,7 @@ body {
   background: rgba(245, 222, 64, 0.05);
   transform: translateY(-3px) scale(1.02);
   box-shadow: 0 10px 25px rgba(245, 222, 64, 0.2);
+  z-index: 10; /* Bring to front on hover */
 }
 
 .flight-plan.selected {

--- a/server.js
+++ b/server.js
@@ -124,12 +124,13 @@ async function pollControllers() {
       throw new Error(`HTTP ${response.status} - ${response.statusText}`);
     }
     const data = await response.json();
+    const filteredData = data.filter(c => c.position && (c.position.endsWith('_TWR') || c.position.endsWith('_GND')));
     controllerCache = {
-      data: data,
+      data: filteredData,
       lastUpdated: new Date().toISOString(),
       source: 'live'
     };
-    logWithTimestamp('info', 'Fetched controller data successfully', { count: data.length });
+    logWithTimestamp('info', 'Fetched controller data successfully', { originalCount: data.length, filteredCount: filteredData.length });
   } catch (error) {
     logWithTimestamp('error', 'Failed to fetch controller data', { error: error.message });
     controllerCache.source = 'stale'; // Mark data as potentially stale
@@ -221,7 +222,6 @@ let adminSettings = {
     includeAtis: true,
     includeSquawk: true,
     includeFlightLevel: true,
-    phraseologyStyle: "ICAO", // ICAO, FAA, Local
     customTemplate: "{CALLSIGN}, {ATC_STATION}, good day. Startup approved. Information {ATIS} is correct. Cleared to {DESTINATION} via {ROUTE}, runway {RUNWAY}. Initial climb {INITIAL_ALT}FT, expect further climb to Flight Level {FLIGHT_LEVEL}. Squawk {SQUAWK}.",
     includeStartupApproval: true,
     includeInitialClimb: true


### PR DESCRIPTION
This commit introduces several improvements to the application based on user feedback.

1.  **Filter Controller List:** The `server.js` file has been updated to filter the controller list fetched from the external API. It now only includes `_TWR` (Tower) and `_GND` (Ground) positions, as these are the only types from which clearance can be requested via this tool.

2.  **Refactor Phraseology Settings:**
    - The "Phraseology Standard" dropdown has been removed from both the main page's advanced configuration and the admin panel.
    - The `customTemplate` is now the single source for the global default phraseology format. Admins can set this template, and it will be stored in the database and served to all users as the default.
    - The database migration script, server-side logic (`server.js`), admin panel (`public/admin.html`), and main page (`public/index.html`) have all been updated to reflect this new, simplified approach.

3.  **Fix Flight Plan UI Bug:**
    - A CSS issue causing flight plan items to be clipped during their hover animation has been resolved. This was fixed by removing `overflow: hidden` from the `.flight-plan` style and adjusting `z-index` and `overflow-x` properties on the relevant elements in `public/styles.css`.