### PR TITLE
Fix: Fetch global clearance format from a public endpoint

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -814,7 +814,7 @@
   // Load admin settings for the frontend
   async function loadAdminSettings() {
     try {
-      const response = await fetch('/api/admin/settings?password=guest');
+      const response = await fetch('/api/settings');
       if (response.ok) {
         const settings = await response.json();
         if (settings && !settings.error) {

--- a/server.js
+++ b/server.js
@@ -1599,6 +1599,24 @@ app.get("/api/admin/analytics", async (req, res) => {
   }
 });
 
+// PUBLIC: Get public-facing admin settings
+app.get("/api/settings", (req, res) => {
+  try {
+    // Expose only non-sensitive settings
+    const publicSettings = {
+      clearanceFormat: adminSettings.clearanceFormat,
+      aviation: {
+        defaultAltitudes: adminSettings.aviation.defaultAltitudes,
+        squawkRanges: adminSettings.aviation.squawkRanges
+      }
+    };
+    res.json(publicSettings);
+  } catch (error) {
+    logWithTimestamp('error', 'Failed to retrieve public settings', { error: error.message });
+    res.status(500).json({ error: 'Could not retrieve settings' });
+  }
+});
+
 app.get("/api/admin/settings", (req, res) => {
   // Check if user is authenticated and is admin
   if (!req.session?.user || !req.session.user.is_admin) {


### PR DESCRIPTION
The frontend was not correctly displaying the global clearance format settings because it was attempting to fetch them from a protected admin-only API endpoint (`/api/admin/settings`). This resulted in an authentication failure for regular users, causing the application to fall back to hardcoded default settings.

This change introduces a new public API endpoint, `/api/settings`, which exposes only the non-sensitive, public-facing settings, including the `clearanceFormat` and `aviation` configurations. The main application's frontend (`public/index.html`) has been updated to use this new endpoint, allowing all users to receive the correct global settings by default.

The existing `/api/admin/settings` endpoint remains unchanged and protected, ensuring that the admin panel continues to function securely.