### PR TITLE
Fix final set of backend errors

### DIFF
--- a/migrations.sql
+++ b/migrations.sql
@@ -58,6 +58,18 @@ CREATE TABLE public.admin_settings (
     CONSTRAINT single_row_constraint CHECK (id = 1)
 );
 
+CREATE TABLE public.flight_plans_received (
+    id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+    callsign TEXT NOT NULL,
+    destination TEXT,
+    route TEXT,
+    flight_level TEXT,
+    source TEXT DEFAULT 'Main',
+    raw_data JSONB,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX ON public.flight_plans_received(callsign);
+
 -- =============================================================================
 -- Functions
 -- =============================================================================
@@ -192,12 +204,14 @@ $$;
 ALTER TABLE public.discord_users ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.clearance_generations ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.admin_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.flight_plans_received ENABLE ROW LEVEL SECURITY;
 
 -- Policies
 -- service_role has full access
 CREATE POLICY "Service role full access" ON public.discord_users FOR ALL TO service_role USING (true) WITH CHECK (true);
 CREATE POLICY "Service role full access" ON public.clearance_generations FOR ALL TO service_role USING (true) WITH CHECK (true);
 CREATE POLICY "Service role full access" ON public.admin_settings FOR ALL TO service_role USING (true) WITH CHECK (true);
+CREATE POLICY "Service role full access" ON public.flight_plans_received FOR ALL TO service_role USING (true) WITH CHECK (true);
 
 -- Admins can manage users and settings
 CREATE POLICY "Admins can manage discord_users" ON public.discord_users FOR ALL TO authenticated USING (is_admin()) WITH CHECK (is_admin());
@@ -210,10 +224,14 @@ CREATE POLICY "Users can view their own data" ON public.discord_users FOR SELECT
 CREATE POLICY "Anon can insert clearances" ON public.clearance_generations FOR INSERT TO anon WITH CHECK (true);
 CREATE POLICY "Admins can see all clearances" ON public.clearance_generations FOR SELECT TO authenticated USING (is_admin());
 
+-- Allow anonymous read on flight plans
+CREATE POLICY "Anon can read flight plans" ON public.flight_plans_received FOR SELECT TO anon USING (true);
+
 -- Force RLS
 ALTER TABLE public.discord_users FORCE ROW LEVEL SECURITY;
 ALTER TABLE public.clearance_generations FORCE ROW LEVEL SECURITY;
 ALTER TABLE public.admin_settings FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.flight_plans_received FORCE ROW LEVEL SECURITY;
 
 
 -- =============================================================================
@@ -221,7 +239,8 @@ ALTER TABLE public.admin_settings FORCE ROW LEVEL SECURITY;
 -- =============================================================================
 GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role;
 GRANT ALL ON ALL TABLES IN SCHEMA public TO service_role;
-GRANT SELECT ON public.discord_users, public.clearance_generations, public.admin_settings TO authenticated;
+GRANT SELECT ON public.discord_users, public.clearance_generations, public.admin_settings, public.flight_plans_received TO authenticated;
+GRANT SELECT ON public.flight_plans_received TO anon;
 GRANT INSERT ON public.clearance_generations TO anon, authenticated;
 GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO anon, authenticated, service_role;
 


### PR DESCRIPTION
This commit addresses the final set of errors identified from the runtime logs.

- **Database Migration:** The `flight_plans_received` table, which was being queried by the API, has been added back to the `migrations.sql` file along with its RLS policies and permissions.

- **Timestamp Conversion:** Fixes a `date/time field value out of range` error during the OAuth callback. The backend now converts the token expiration time to a standard ISO 8601 string before sending it to the database, ensuring correct parsing.

- **Backend Refactoring:** The backend has been refactored into a pure API server.
  - It no longer attempts to serve the frontend's static files, which was causing `NotFound` errors.
  - The OAuth callback now redirects to a full `FRONTEND_URL` (configurable via an environment variable) instead of a relative path. This ensures a clean separation between the backend and frontend applications.
  - The 404 error handler has been simplified to always return a JSON response.

These changes should resolve all remaining Internal Server Errors and allow the authentication flow to complete successfully.