### PR TITLE
fix: Implement dynamic frontend redirect after auth

### DIFF
--- a/frontend/src/auth.js
+++ b/frontend/src/auth.js
@@ -33,7 +33,8 @@ export async function checkAuthStatus(updateUI) {
 
 export function loginWithDiscord() {
   sessionStorage.setItem('authRedirectPath', window.location.pathname);
-  window.location.href = `${API_BASE_URL}/auth/discord`;
+  const origin = window.location.origin;
+  window.location.href = `${API_BASE_URL}/auth/discord?origin=${encodeURIComponent(origin)}`;
 }
 
 export async function logout(updateUI) {


### PR DESCRIPTION
This commit fixes an issue where the backend would always redirect to the production frontend URL after a successful Discord authentication, making it impossible to test the login flow on preview deployments.

The authentication flow has been updated to support dynamic redirects:
-   The frontend (`frontend/src/auth.js`) now passes its origin URL to the backend's `/auth/discord` endpoint as a query parameter.
-   The backend (`backend/auth.py`) captures this origin URL and stores it in the user's session.
-   After the Discord callback is processed, the backend retrieves the origin URL from the session and uses it for the final redirect.

This allows the same backend to handle logins from multiple frontend environments (e.g., production and Cloudflare Pages previews) and redirect users back to the correct one.