### PR TITLE
fix: Import supabase_admin client in api.py

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, jsonify, request, session, current_app
-from .database import supabase
+from .database import supabase, supabase_admin
 from .services import external_api_service, flight_plans_cache
 from .auth_utils import require_auth
 


### PR DESCRIPTION
This commit fixes a `NameError` that was occurring in the `get_public_settings` endpoint. The endpoint was trying to use the `supabase_admin` client without importing it from the `database` module.

This change adds the necessary import to `backend/api.py`, which resolves the `NameError` and allows the public settings to be fetched correctly.