### PR TITLE
fix: Resolve race condition in authentication flow

### DIFF
--- a/frontend/admin.js
+++ b/frontend/admin.js
@@ -738,8 +738,10 @@ function showSection(sectionName) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  checkAuthParams(updateAuthUI);
-  checkAuthStatus(updateAuthUI);
+  const authHandled = checkAuthParams(updateAuthUI);
+  if (!authHandled) {
+    checkAuthStatus(updateAuthUI);
+  }
 });
 
 window.logout = () => logout(updateAuthUI);

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -672,8 +672,10 @@ async function initializeApp() {
     console.error(e.message);
     return; // Stop initialization
   }
-  checkAuthParams(updateAuthUI);
-  checkAuthStatus(updateAuthUI);
+  const authHandled = checkAuthParams(updateAuthUI);
+  if (!authHandled) {
+    checkAuthStatus(updateAuthUI);
+  }
   showContactNotification();
   loadControllers();
   loadFlightPlans();

--- a/frontend/src/auth.js
+++ b/frontend/src/auth.js
@@ -70,7 +70,7 @@ export function checkAuthParams(updateUI) {
     // Reconstruct the URL to be on the root path
     const newUrl = window.location.origin + '/?' + urlParams.toString();
     window.location.href = newUrl;
-    return; // Stop execution to allow for redirect
+    return true; // Stop execution to allow for redirect
   }
 
   if (authResult === 'success') {
@@ -81,6 +81,7 @@ export function checkAuthParams(updateUI) {
     window.history.replaceState({}, document.title, redirectPath);
     // Check auth status to update UI
     setTimeout(() => checkAuthStatus(updateUI), 500);
+    return true;
   } else if (authError) {
     console.error('Discord authentication error:', authError);
     showAuthError(authError);
@@ -88,7 +89,10 @@ export function checkAuthParams(updateUI) {
     sessionStorage.removeItem('authRedirectPath');
     // Remove the param from URL and set path to the stored path
     window.history.replaceState({}, document.title, redirectPath);
+    return true;
   }
+
+  return false;
 }
 
 export function getCurrentUser() {


### PR DESCRIPTION
This commit fixes a race condition that occurred after a user logged in. The page was attempting to check the user's authentication status before the post-login redirect and session update were fully processed. This resulted in the UI not updating correctly until the user manually refreshed the page.

The fix involves refactoring the initialization logic in `index.js` and `admin.js`:
-   The `checkAuthParams` function in `auth.js` now returns a boolean indicating whether it handled a post-login redirect.
-   The `DOMContentLoaded` listeners in `index.js` and `admin.js` now check this return value. They only call `checkAuthStatus` on a normal page load, and not immediately after a login redirect, allowing the session to be correctly established first.

This ensures that the UI always displays the correct state immediately after login without requiring a manual refresh.